### PR TITLE
Downgrade slf4j-simple to version 1.7.5

### DIFF
--- a/jetty/jaas-jetty-crowd/pom.xml
+++ b/jetty/jaas-jetty-crowd/pom.xml
@@ -23,12 +23,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.22</version>
+			<version>1.7.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.22</version>
+			<version>1.7.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Otherwise, the library fails with java.lang.ExceptionInInitializerError,
because multiple versions of the same libraries are available in the
class path:

```
javax.security.auth.login.LoginException: java.lang.ExceptionInInitializerError
        at com.sun.jersey.client.apache.config.ApacheHttpClientState.<init>(ApacheHttpClientState.java:61)
        at be.greenhand.jaas.jetty.CrowdLoginModule.restClientInit(CrowdLoginModule.java:243)
        at be.greenhand.jaas.jetty.CrowdLoginModule.initialize(CrowdLoginModule.java:106)
[...]
Caused by: org.apache.commons.logging.LogConfigurationException: org.apache.commons.logging.LogConfigurationException: org.apache.commons.logging.LogConfigurationException: Invalid class loader hierarchy.  You have more than one version of 'org.apache.commons.logging.Log' visible, which is not allowed.
```